### PR TITLE
fix bug in update.*

### DIFF
--- a/R/hier_clust.R
+++ b/R/hier_clust.R
@@ -70,7 +70,9 @@ update.hier_clust <- function(object,
                               cut_height = NULL,
                               linkage_method = NULL,
                               fresh = FALSE, ...) {
-  eng_args <- parsnip::update_engine_parameters(object$eng_args, ...)
+  eng_args <- parsnip::update_engine_parameters(
+    object$eng_args, fresh = fresh, ...
+  )
 
   if (!is.null(parameters)) {
     parameters <- parsnip::check_final_param(parameters)

--- a/R/k_means.R
+++ b/R/k_means.R
@@ -64,7 +64,9 @@ update.k_means <- function(object,
                            parameters = NULL,
                            num_clusters = NULL,
                            fresh = FALSE, ...) {
-  eng_args <- parsnip::update_engine_parameters(object$eng_args, ...)
+  eng_args <- parsnip::update_engine_parameters(
+    object$eng_args, fresh = fresh, ...
+  )
 
   if (!is.null(parameters)) {
     parameters <- parsnip::check_final_param(parameters)


### PR DESCRIPTION
To close https://github.com/tidymodels/tidyclust/issues/89

``` r
library(tidyverse)
library(tidymodels)
library(tidyclust)

data("penguins", package = "modeldata")
data <- penguins %>%
  as_tibble() %>%
  drop_na()

rec <- data %>%  
  recipe(~ bill_length_mm + bill_depth_mm) %>% 
  step_normalize(all_numeric_predictors())

model <- k_means(
  num_clusters = tune()
) %>%
  set_engine("stats", algorithm = "Lloyd", iter.max = 50) 

learner <- workflow() %>% 
  add_recipe(rec) %>% 
  add_model(model)

custom_grid <- crossing(
  num_clusters = seq(2, 10, 1)
)

cv_folds <- data %>%
  vfold_cv(v = 3, repeats = 1)

at <- tune_cluster(
  learner,
  resamples = cv_folds,
  grid = custom_grid,
  control = control_grid(save_pred = TRUE, extract = identity),
  metrics = cluster_metric_set(sse_within_total, sse_total, sse_ratio)
)

best <- tibble(
  num_clusters = 2
)

final_learner <- learner %>% finalize_workflow_tidyclust(best)
final_learner
#> ══ Workflow ════════════════════════════════════════════════════════════════════
#> Preprocessor: Recipe
#> Model: k_means()
#> 
#> ── Preprocessor ────────────────────────────────────────────────────────────────
#> 1 Recipe Step
#> 
#> • step_normalize()
#> 
#> ── Model ───────────────────────────────────────────────────────────────────────
#> K Means Cluster Specification (partition)
#> 
#> Main Arguments:
#>   num_clusters = 2
#> 
#> Engine-Specific Arguments:
#>   algorithm = Lloyd
#>   iter.max = 50
#> 
#> Computational engine: stats
```

<sup>Created on 2022-11-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>