### PR TITLE
make sure ClusterR predict method also rearranges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyclust (development version)
 
+* Fixed bug where `extract_cluster_assignment()` and `predict()` sometimes didn't have agreement of clusters. (#94)
+
 * `silhouette()` and `silhouette_avg()` now return NAs instead of erroring when applied to a clustering object with 1 cluster. (#104)
 
 * Fixed bug where `extract_cluster_assignment()` doesn't work for `hier_clust()` models in workflows where `num_clusters` is specified in `extract_cluster_assignment()`.

--- a/R/extract_assignment.R
+++ b/R/extract_assignment.R
@@ -62,7 +62,7 @@ cluster_assignment_tibble <- function(clusters,
                                       n_clusters,
                                       ...,
                                       prefix = "Cluster_") {
-  reorder_clusts <- order(unique(clusters))
+  reorder_clusts <- order(union(unique(clusters), seq_len(n_clusters)))
   names <- paste0(prefix, seq_len(n_clusters))
   res <- names[reorder_clusts][clusters]
 

--- a/R/predict_helpers.R
+++ b/R/predict_helpers.R
@@ -7,8 +7,13 @@ stats_kmeans_predict <- function(object, new_data, prefix = "Cluster_") {
 }
 
 clusterR_kmeans_predict <- function(object, new_data, prefix = "Cluster_") {
-  res <- predict(object, new_data)
-  res <- paste0(prefix, res)
+  clusters <- predict(object, new_data)
+  n_clusters <- length(object$obs_per_cluster)
+
+  reorder_clusts <- order(union(unique(clusters), seq_len(n_clusters)))
+  names <- paste0(prefix, seq_len(n_clusters))
+  res <- names[reorder_clusts][clusters]
+
   factor(res)
 }
 


### PR DESCRIPTION
to close #94 

``` r
library(tidymodels)
library(tidyclust)

data("ames", package = "modeldata")

kmeans_spec <- k_means(num_clusters = 4) %>%
  set_engine("ClusterR")

rec_spec <- recipe(~ ., data = ames) %>%
  step_dummy(all_nominal_predictors())

kmeans_wf <- workflow(rec_spec, kmeans_spec)
kmeans_fit <- fit(kmeans_wf, data = ames)

extract_cluster_assignment(kmeans_fit)
#> # A tibble: 2,930 × 1
#>    .cluster 
#>    <fct>    
#>  1 Cluster_1
#>  2 Cluster_2
#>  3 Cluster_1
#>  4 Cluster_3
#>  5 Cluster_1
#>  6 Cluster_1
#>  7 Cluster_1
#>  8 Cluster_1
#>  9 Cluster_3
#> 10 Cluster_1
#> # … with 2,920 more rows

predict(kmeans_fit, new_data = ames[c(1:10), ])
#> # A tibble: 10 × 1
#>    .pred_cluster
#>    <fct>        
#>  1 Cluster_1    
#>  2 Cluster_2    
#>  3 Cluster_1    
#>  4 Cluster_3    
#>  5 Cluster_1    
#>  6 Cluster_1    
#>  7 Cluster_1    
#>  8 Cluster_1    
#>  9 Cluster_3    
#> 10 Cluster_1
```

<sup>Created on 2022-12-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>