### PR TITLE
Standardize Posit name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R: c(
     person("Emil", "Hvitfeldt", , "emilhhvitfeldt@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0679-1945")),
     person("Kelly", "Bodwin", , "kelly@bodwin.us", role = "aut"),
-    person("Posit Software, PBC.", role = c("cph", "fnd"))
+    person("Posit Software, PBC", role = c("cph", "fnd"))
   )
 Description: A common interface to specifying clustering models, in the
     same style as 'parsnip'. Creates unified interface across different


### PR DESCRIPTION
I scraped CRAN to find companies that fund R packages, and noticed that Posit is credited 6 different ways (9 if you include RStudio/RStudio PBC/RStudio, PBC). I'm submitting PRs with the official "Posit Software, PBC" name on the few Posit varieties to nip it in the bud.