### PR TITLE
pass arguments to clusterR::KMeans_rcpp()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyclust (development version)
 
+* Fix bug where engine specific arguments were passed along for `k_means()` when the engine ClusterR. (#142)
+
 # tidyclust 0.1.2
 
 * The cluster specification methods for `generics::tune_args()` and `generics::tunable()` are now registered unconditionally (#115).

--- a/R/k_means.R
+++ b/R/k_means.R
@@ -155,7 +155,19 @@ ClusterR_kmeans_fit <- function(data, clusters, num_init = 1, max_iters = 100,
                                 initializer = "kmeans++", fuzzy = FALSE,
                                 verbose = FALSE, CENTROIDS = NULL, tol = 1e-04,
                                 tol_optimal_init = 0.3, seed = 1) {
-  res <- ClusterR::KMeans_rcpp(data, clusters)
+  res <- ClusterR::KMeans_rcpp(
+    data,
+    clusters,
+    num_init = num_init,
+    max_iters = max_iters,
+    initializer = initializer,
+    fuzzy = fuzzy,
+    verbose = verbose,
+    CENTROIDS = CENTROIDS,
+    tol = tol,
+    tol_optimal_init = tol_optimal_init,
+    seed = seed
+  )
   colnames(res$centroids) <- colnames(data)
   res
 }

--- a/tests/testthat/test-k_means.R
+++ b/tests/testthat/test-k_means.R
@@ -119,3 +119,17 @@ test_that("updating", {
       update(num_clusters = tune())
   )
 })
+
+test_that("Engine-specific arguments are passed to ClusterR models", {
+  spec <- k_means(num_clusters = 2) %>%
+    set_engine("ClusterR", fuzzy = FALSE)
+
+  fit <- fit(spec, ~., data = mtcars)
+  expect_true(is.null(fit$fit$fuzzy_clusters))
+
+  spec <- k_means(num_clusters = 2) %>%
+    set_engine("ClusterR", fuzzy = TRUE)
+
+  fit <- fit(spec, ~., data = mtcars)
+  expect_false(is.null(fit$fit$fuzzy_clusters))
+})


### PR DESCRIPTION
Fix bug where engine specific arguments were passed along for `k_means()` when the engine ClusterR.