### PR TITLE
make sure that prefix argument is passed through extraction functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # tidyclust (development version)
 
-* Fix bug where engine specific arguments were passed along for `k_means()` when the engine ClusterR. (#142)
+* Fixed bug where engine specific arguments were passed along for `k_means()` when the engine ClusterR. (#142)
+
+* Fixed bug where `prefix` argument wouldn't be correctly passed through `extract_cluster_assignment()`, `extract_centroids()`, and `predict()` (#145)
 
 # tidyclust 0.1.2
 

--- a/R/extract_cluster_assignment.R
+++ b/R/extract_cluster_assignment.R
@@ -47,6 +47,9 @@
 #' kmeans_fit %>%
 #'   extract_cluster_assignment()
 #'
+#' kmeans_fit %>%
+#'   extract_cluster_assignment(prefix = "C_")
+#'
 #' # Some models such as `hier_clust()` fits in such a way that you can specify
 #' # the number of clusters after the model is fit
 #' hclust_spec <- hier_clust() %>%
@@ -86,12 +89,13 @@ extract_cluster_assignment.workflow <- function(object, ...) {
 
 #' @export
 extract_cluster_assignment.kmeans <- function(object, ...) {
-  cluster_assignment_tibble(object$cluster, length(object$size))
+  cluster_assignment_tibble(object$cluster, length(object$size), ...)
 }
 
 #' @export
 extract_cluster_assignment.KMeansCluster <- function(object, ...) {
-  cluster_assignment_tibble(object$clusters, length(object$obs_per_cluster))
+  n_clusters <- length(object$obs_per_cluster)
+  cluster_assignment_tibble(object$clusters, n_clusters, ...)
 }
 
 #' @export

--- a/R/extract_fit_summary.R
+++ b/R/extract_fit_summary.R
@@ -45,9 +45,9 @@ extract_fit_summary.workflow <- function(object, ...) {
 }
 
 #' @export
-extract_fit_summary.kmeans <- function(object, ...) {
+extract_fit_summary.kmeans <- function(object, ..., prefix = "Cluster_") {
   reorder_clusts <- order(unique(object$cluster))
-  names <- paste0("Cluster_", seq_len(nrow(object$centers)))
+  names <- paste0(prefix, seq_len(nrow(object$centers)))
   names <- factor(names)
 
   cluster_asignments <- factor(
@@ -70,9 +70,11 @@ extract_fit_summary.kmeans <- function(object, ...) {
 }
 
 #' @export
-extract_fit_summary.KMeansCluster <- function(object, ...) {
+extract_fit_summary.KMeansCluster <- function(object,
+                                              ...,
+                                              prefix = "Cluster_") {
   reorder_clusts <- order(unique(object$cluster))
-  names <- paste0("Cluster_", seq_len(nrow(object$centroids)))
+  names <- paste0(prefix, seq_len(nrow(object$centroids)))
   names <- factor(names)
 
   cluster_asignments <- factor(

--- a/man/extract_cluster_assignment.Rd
+++ b/man/extract_cluster_assignment.Rd
@@ -56,6 +56,9 @@ kmeans_fit <- fit(kmeans_spec, ~., mtcars)
 kmeans_fit \%>\%
   extract_cluster_assignment()
 
+kmeans_fit \%>\%
+  extract_cluster_assignment(prefix = "C_")
+
 # Some models such as `hier_clust()` fits in such a way that you can specify
 # the number of clusters after the model is fit
 hclust_spec <- hier_clust() \%>\%

--- a/tests/testthat/test-extract_centroids.R
+++ b/tests/testthat/test-extract_centroids.R
@@ -6,3 +6,14 @@ test_that("extract_centroids() errors for cluster spec", {
     extract_centroids(spec)
   )
 })
+
+test_that("prefix is passed in extract_centroids()", {
+  spec <- tidyclust::k_means(num_clusters = 4) %>%
+    fit(~ ., data = mtcars)
+
+  res <- extract_centroids(spec, prefix = "C_")
+
+  expect_true(
+    all(substr(res$.cluster, 1, 2) == "C_")
+  )
+})

--- a/tests/testthat/test-extract_cluster_assignment.R
+++ b/tests/testthat/test-extract_cluster_assignment.R
@@ -6,3 +6,14 @@ test_that("extract_cluster_assignment() errors for cluster spec", {
     extract_cluster_assignment(spec)
   )
 })
+
+test_that("prefix is passed in extract_cluster_assignment()", {
+  spec <- tidyclust::k_means(num_clusters = 4) %>%
+    fit(~ ., data = mtcars)
+
+  res <- extract_cluster_assignment(spec, prefix = "C_")
+
+  expect_true(
+    all(substr(res$.cluster, 1, 2) == "C_")
+  )
+})

--- a/tests/testthat/test-extract_fit_summary.R
+++ b/tests/testthat/test-extract_fit_summary.R
@@ -63,3 +63,14 @@ test_that("extract_fit_summary() errors for cluster spec", {
     extract_fit_summary(spec)
   )
 })
+
+test_that("prefix is passed in extract_fit_summary()", {
+  spec <- tidyclust::k_means(num_clusters = 4) %>%
+    fit(~ ., data = mtcars)
+
+  res <- extract_fit_summary(spec, prefix = "C_")
+
+  expect_true(
+    all(substr(res$.cluster, 1, 2) == "C_")
+  )
+})

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -6,3 +6,14 @@ test_that("predict() errors for cluster spec", {
     predict(spec)
   )
 })
+
+test_that("prefix is passed in predict()", {
+  spec <- tidyclust::k_means(num_clusters = 4) %>%
+    fit(~ ., data = mtcars)
+
+  res <- predict(spec, mtcars, prefix = "C_")
+
+  expect_true(
+    all(substr(res$.pred_cluster, 1, 2) == "C_")
+  )
+})


### PR DESCRIPTION
These functions now follow the documented behavior. 

``` r
library(tidyclust)

spec <- k_means(num_clusters = 4) |>
  fit(~., data = mtcars)

extract_centroids(spec)
#> # A tibble: 4 × 12
#>   .cluster    mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
#>   <fct>     <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1 Cluster_1  15.1     8 353.  209.   3.23  4.00  16.8 0     0.143  3.29  3.5 
#> 2 Cluster_2  19.7     6 183.  122.   3.59  3.12  18.0 0.571 0.429  3.86  3.43
#> 3 Cluster_3  24.2     4 122.   94.3  3.92  2.51  19.1 0.857 0.571  4.14  1.71
#> 4 Cluster_4  31       4  76.1  62.2  4.33  1.90  19.2 1     1      4     1.25

extract_centroids(spec, prefix = "c_")
#> # A tibble: 4 × 12
#>   .cluster   mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
#>   <fct>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#> 1 c_1       15.1     8 353.  209.   3.23  4.00  16.8 0     0.143  3.29  3.5 
#> 2 c_2       19.7     6 183.  122.   3.59  3.12  18.0 0.571 0.429  3.86  3.43
#> 3 c_3       24.2     4 122.   94.3  3.92  2.51  19.1 0.857 0.571  4.14  1.71
#> 4 c_4       31       4  76.1  62.2  4.33  1.90  19.2 1     1      4     1.25

extract_cluster_assignment(spec)
#> # A tibble: 32 × 1
#>    .cluster 
#>    <fct>    
#>  1 Cluster_1
#>  2 Cluster_1
#>  3 Cluster_2
#>  4 Cluster_1
#>  5 Cluster_3
#>  6 Cluster_1
#>  7 Cluster_3
#>  8 Cluster_2
#>  9 Cluster_2
#> 10 Cluster_1
#> # ℹ 22 more rows

extract_cluster_assignment(spec, prefix = "c_")
#> # A tibble: 32 × 1
#>    .cluster
#>    <fct>   
#>  1 c_1     
#>  2 c_1     
#>  3 c_2     
#>  4 c_1     
#>  5 c_3     
#>  6 c_1     
#>  7 c_3     
#>  8 c_2     
#>  9 c_2     
#> 10 c_1     
#> # ℹ 22 more rows

predict(spec, mtcars)
#> # A tibble: 32 × 1
#>    .pred_cluster
#>    <fct>        
#>  1 Cluster_1    
#>  2 Cluster_1    
#>  3 Cluster_2    
#>  4 Cluster_1    
#>  5 Cluster_3    
#>  6 Cluster_1    
#>  7 Cluster_3    
#>  8 Cluster_2    
#>  9 Cluster_2    
#> 10 Cluster_1    
#> # ℹ 22 more rows

predict(spec, mtcars, prefix = "c_")
#> # A tibble: 32 × 1
#>    .pred_cluster
#>    <fct>        
#>  1 c_1          
#>  2 c_1          
#>  3 c_2          
#>  4 c_1          
#>  5 c_3          
#>  6 c_1          
#>  7 c_3          
#>  8 c_2          
#>  9 c_2          
#> 10 c_1          
#> # ℹ 22 more rows
```

<sup>Created on 2023-08-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>