### PR TITLE
Fix bug where tune_cluster doesn't like id variables in recipes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 * Fixed bug where levels didn't match number of clusters if prediction on fewer number of observations. (#158)
 
+* Fixed bug where `tune_cluster()` would error if used with an recipe that contained non-predictor variables such as id variables. (#124)
+
 # tidyclust 0.1.2
 
 * The cluster specification methods for `generics::tune_args()` and `generics::tunable()` are now registered unconditionally (#115).

--- a/R/metric-aaa.R
+++ b/R/metric-aaa.R
@@ -234,7 +234,7 @@ extract_post_preprocessor <- function(object, new_data) {
   } else if (inherits(preprocessor, "recipe")) {
     new_data <- object %>%
       hardhat::extract_recipe() %>%
-      recipes::bake(new_data)
+      recipes::bake(new_data, recipes::all_predictors())
   }
   new_data
 }


### PR DESCRIPTION
To close #124 

``` r
pacman::p_load(tidyverse, tidymodels, tidyclust, janitor, ClusterR)

data <- mtcars %>%
  rownames_to_column(var = "model")

kmeans_spec <- k_means(num_clusters = 4) %>%
  set_engine("ClusterR")

rec_spec <- recipe(~., data = data) %>%
  update_role(model, new_role = "id variable") %>%
  step_dummy(all_nominal_predictors()) %>%
  step_zv(all_predictors()) %>%
  step_normalize(all_numeric_predictors()) %>%
  step_pca(all_numeric_predictors(), threshold = 0.8)

kmeans_spec <- kmeans_spec %>%
  set_args(num_clusters = tune())

kmeans_wf <- workflow(rec_spec, kmeans_spec)

set.seed(1234)

boots <- bootstraps(data, times = 10)

tune_res <- tune_cluster(
  kmeans_wf,
  resamples = boots
)

tune_res
#> # Tuning results
#> # Bootstrap sampling 
#> # A tibble: 10 × 4
#>    splits          id          .metrics          .notes          
#>    <list>          <chr>       <list>            <list>          
#>  1 <split [32/13]> Bootstrap01 <tibble [16 × 5]> <tibble [0 × 3]>
#>  2 <split [32/7]>  Bootstrap02 <tibble [16 × 5]> <tibble [0 × 3]>
#>  3 <split [32/12]> Bootstrap03 <tibble [16 × 5]> <tibble [0 × 3]>
#>  4 <split [32/11]> Bootstrap04 <tibble [16 × 5]> <tibble [0 × 3]>
#>  5 <split [32/11]> Bootstrap05 <tibble [16 × 5]> <tibble [0 × 3]>
#>  6 <split [32/10]> Bootstrap06 <tibble [16 × 5]> <tibble [0 × 3]>
#>  7 <split [32/9]>  Bootstrap07 <tibble [16 × 5]> <tibble [0 × 3]>
#>  8 <split [32/11]> Bootstrap08 <tibble [16 × 5]> <tibble [0 × 3]>
#>  9 <split [32/14]> Bootstrap09 <tibble [16 × 5]> <tibble [0 × 3]>
#> 10 <split [32/11]> Bootstrap10 <tibble [16 × 5]> <tibble [0 × 3]>
```

<sup>Created on 2023-08-31 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>