### PR TITLE
capture and reformulate advice when clustMixType models error

### DIFF
--- a/tests/testthat/_snaps/k_means-clustMixType.md
+++ b/tests/testthat/_snaps/k_means-clustMixType.md
@@ -1,0 +1,21 @@
+# modifies errors about suggested other models
+
+    Code
+      k_means(num_clusters = 3) %>% set_engine("clustMixType") %>% fit(~., data = mtcars)
+    Condition
+      Error in `fit()`:
+      ! Engine `clustMixType` requires both numeric and categorical predictors.
+      x Only numeric predictors where used.
+      i Try using the `stats` engine with `mod %>% set_engine("stats")`.
+
+---
+
+    Code
+      k_means(num_clusters = 3) %>% set_engine("clustMixType") %>% fit(~., data = data.frame(
+        letters, LETTERS))
+    Condition
+      Error in `fit()`:
+      ! Engine `clustMixType` requires both numeric and categorical predictors.
+      x Only categorical predictors where used.
+      i Try using the `klaR` engine with `mod %>% set_engine("klaR")`.
+

--- a/tests/testthat/test-k_means-clustMixType.R
+++ b/tests/testthat/test-k_means-clustMixType.R
@@ -97,3 +97,22 @@ test_that("extract_cluster_assignment() works", {
     expected
   )
 })
+
+test_that("modifies errors about suggested other models", {
+  skip_if_not_installed("clustMixType")
+
+  expect_snapshot(
+    error = TRUE,
+    k_means(num_clusters = 3) %>%
+      set_engine("clustMixType") %>%
+      fit(~., data = mtcars)
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    k_means(num_clusters = 3) %>%
+      set_engine("clustMixType") %>%
+      fit(~., data = data.frame(letters, LETTERS))
+  )
+})
+


### PR DESCRIPTION
to close #160 

``` r
library(tidyclust)

k_means(num_clusters = 3) %>%
  set_engine("clustMixType") %>%
  fit(~., data = iris)
#> tidyclust cluster object
#> 
#> Distance type: standard 
#> 
#> Numeric predictors: 4 
#> Categorical predictors: 1 
#> Lambda: 1.714859 
#> 
#> Number of Clusters: 3 
#> Cluster sizes: 50 51 49 
#> Within cluster error: 15.151 33.64858 39.15551 
#> 
#> Cluster prototypes:
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width    Species
#> 1     5.006000    3.428000     1.462000    0.246000     setosa
#> 2     5.915686    2.764706     4.264706    1.333333 versicolor
#> 3     6.622449    2.983673     5.573469    2.032653  virginica

k_means(num_clusters = 3) %>%
  set_engine("clustMixType") %>%
  fit(~., data = mtcars)
#> Error in `fit()`:
#> ! Engine `clustMixType` requires both numeric and categorical
#>   predictors.
#> ✖ Only numeric predictors where used.
#> ℹ Try using the `stats` engine with `mod %>% set_engine("stats")`.

k_means(num_clusters = 3) %>%
  set_engine("clustMixType") %>%
  fit(~., data = data.frame(letters, LETTERS))
#> Error in `fit()`:
#> ! Engine `clustMixType` requires both numeric and categorical
#>   predictors.
#> ✖ Only categorical predictors where used.
#> ℹ Try using the `klaR` engine with `mod %>% set_engine("klaR")`.
```