### PR TITLE
add direction in as_tibble.cluster_metric_set()

### DIFF
--- a/R/metric-aaa.R
+++ b/R/metric-aaa.R
@@ -210,7 +210,8 @@ as_tibble.cluster_metric_set <- function(x, ...) {
   names <- names(metrics)
   metrics <- unname(metrics)
   classes <- map_chr(metrics, class1)
-  dplyr::tibble(metric = names, class = classes)
+  directions <- map_chr(metrics, attr, "direction")
+  dplyr::tibble(metric = names, class = classes, direction = directions)
 }
 
 class1 <- function(x) {


### PR DESCRIPTION
This is a simple fix to make {tune} have a clean CRAN release.

Will do the more involved update later.

As far as I can tell, this broke in https://github.com/tidymodels/tune/commit/585e01d804a8496c55a34c13cbe83a78d893904a