### PR TITLE
fix clustMixType test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyclust (development version)
 
+* Update to fix revdep issue for clustMixType. (#190)
+
 # tidyclust 0.2.2
 
 * Update to fix revdep issue for ClusterR. (#186)

--- a/tests/testthat/test-k_means-clustMixType.R
+++ b/tests/testthat/test-k_means-clustMixType.R
@@ -13,7 +13,7 @@ test_that("fitting", {
     res <- fit_xy(spec, iris)
   )
 
-  expect_identical(res$fit$type, "standard")
+  expect_true(res$fit$type %in% c("standard", "huang"))
 
   spec <- k_means(num_clusters = 3) %>%
     set_engine("clustMixType", type = "gower")


### PR DESCRIPTION
Made test more robust to new clustMixType change

> For reasons of consistency we have renamed the default from "standard" into "huang". (Note that the former call using "standard" will still work for reasons of backward compatibility and will return exactly the same result! …but as you don’t specify the type explicitly in your call the returned label oft he type changes.)

