### PR TITLE
Deprecate `finalize_model_tidyclust()` and `finalize_workflow_tidyclust()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Depends:
     R (>= 4.1)
 Imports: 
     cli (>= 3.0.0),
+    lifecycle,
     dials (>= 1.3.0),
     dplyr (>= 1.0.9),
     flexclust (>= 1.3-6),
@@ -55,6 +56,7 @@ Suggests:
     recipes (>= 1.0.0),
     rmarkdown,
     testthat (>= 3.0.0),
+    withr,
     workflows (>= 1.1.2)
 Config/Needs/website: pkgdown, tidymodels, tidyverse, palmerpenguins,
     patchwork, ggforce, tidyverse/tidytemplate, mvtnorm

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyclust (development version)
 
+* `finalize_model_tidyclust()` and `finalize_workflow_tidyclust()` are deprecated. Use `tune::finalize_model()` and `tune::finalize_workflow()` instead, which now support `cluster_spec` objects natively. (#223)
+
 * `tune_cluster()` now warns when passed an `apparent()` resample. Metrics from apparent resamples are excluded by `collect_metrics(summarize = TRUE)` (the default) since tune 1.2.0, which caused unexpected `NA` values. Use `collect_metrics(summarize = FALSE)` to see per-resample metrics. (#193)
 
 * `hier_clust()` documentation now clarifies that `predict()` may not match `extract_cluster_assignment()` on training data. This is expected behavior: `predict()` uses a distance-based heuristic while `extract_cluster_assignment()` uses `cutree()` based on the dendrogram structure. (#208)

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -2,8 +2,12 @@
 
 #' Splice final parameters into objects
 #'
-#' The `finalize_*` functions take a list or tibble of tuning parameter values
-#' and update objects with those values.
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' These functions are deprecated. Please use [tune::finalize_model()] and
+#' [tune::finalize_workflow()] instead, which now support `cluster_spec`
+#' objects natively.
 #'
 #' @param x A recipe, `parsnip` model specification, or workflow.
 #' @param parameters A list or 1-row tibble of parameter values. Note that the
@@ -13,14 +17,20 @@
 #' @return An updated version of `x`.
 #' @examples
 #' kmeans_spec <- k_means(num_clusters = tune())
-#' kmeans_spec
-#'
 #' best_params <- data.frame(num_clusters = 5)
-#' best_params
 #'
+#' # Old:
 #' finalize_model_tidyclust(kmeans_spec, best_params)
+#'
+#' # New:
+#' tune::finalize_model(kmeans_spec, best_params)
 #' @export
 finalize_model_tidyclust <- function(x, parameters) {
+  lifecycle::deprecate_warn(
+    "0.3.0",
+    "finalize_model_tidyclust()",
+    "tune::finalize_model()"
+  )
   if (!inherits(x, "cluster_spec")) {
     cli::cli_abort("{.arg x} should be a tidyclust model specification.")
   }
@@ -45,6 +55,11 @@ finalize_model_tidyclust <- function(x, parameters) {
 #' @rdname finalize_model_tidyclust
 #' @export
 finalize_workflow_tidyclust <- function(x, parameters) {
+  lifecycle::deprecate_warn(
+    "0.3.0",
+    "finalize_workflow_tidyclust()",
+    "tune::finalize_workflow()"
+  )
   if (!inherits(x, "workflow")) {
     cli::cli_abort("{.arg x} should be {.obj_type_friendly workflow}")
   }

--- a/man/finalize_model_tidyclust.Rd
+++ b/man/finalize_model_tidyclust.Rd
@@ -21,15 +21,19 @@ this case, the parameter tibble should be "K" and not "neighbors".}
 An updated version of \code{x}.
 }
 \description{
-The \verb{finalize_*} functions take a list or tibble of tuning parameter values
-and update objects with those values.
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+These functions are deprecated. Please use \code{\link[tune:finalize_model]{tune::finalize_model()}} and
+\code{\link[tune:finalize_model]{tune::finalize_workflow()}} instead, which now support \code{cluster_spec}
+objects natively.
 }
 \examples{
 kmeans_spec <- k_means(num_clusters = tune())
-kmeans_spec
-
 best_params <- data.frame(num_clusters = 5)
-best_params
 
+# Old:
 finalize_model_tidyclust(kmeans_spec, best_params)
+
+# New:
+tune::finalize_model(kmeans_spec, best_params)
 }

--- a/tests/testthat/_snaps/finalize.md
+++ b/tests/testthat/_snaps/finalize.md
@@ -6,6 +6,15 @@
       Error in `finalize_model_tidyclust()`:
       ! `x` should be a tidyclust model specification.
 
+# finalize_model_tidyclust() is deprecated
+
+    Code
+      . <- finalize_model_tidyclust(spec, params)
+    Condition
+      Warning:
+      `finalize_model_tidyclust()` was deprecated in tidyclust 0.3.0.
+      i Please use `tune::finalize_model()` instead.
+
 # finalize_workflow_tidyclust() errors on non-workflow
 
     Code
@@ -13,4 +22,16 @@
     Condition
       Error in `finalize_workflow_tidyclust()`:
       ! `x` should be a string
+
+# finalize_workflow_tidyclust() is deprecated
+
+    Code
+      . <- finalize_workflow_tidyclust(wf, params)
+    Condition
+      Warning:
+      `finalize_workflow_tidyclust()` was deprecated in tidyclust 0.3.0.
+      i Please use `tune::finalize_workflow()` instead.
+      Warning:
+      `finalize_model_tidyclust()` was deprecated in tidyclust 0.3.0.
+      i Please use `tune::finalize_model()` instead.
 

--- a/tests/testthat/test-finalize.R
+++ b/tests/testthat/test-finalize.R
@@ -31,6 +31,30 @@ test_that("finalize_model_tidyclust() errors on non-cluster_spec", {
   )
 })
 
+test_that("tune::finalize_model() works with cluster_spec", {
+  spec <- k_means(num_clusters = tune())
+  params <- data.frame(num_clusters = 5)
+
+  res <- tune::finalize_model(spec, params)
+
+  expect_s3_class(res, "cluster_spec")
+  expect_equal(res$args$num_clusters, new_empty_quosure(5))
+})
+
+test_that("tune::finalize_workflow() works with cluster_spec workflows", {
+  spec <- k_means(num_clusters = tune())
+  wf <- workflows::workflow() |>
+    workflows::add_model(spec) |>
+    workflows::add_formula(~.)
+  params <- data.frame(num_clusters = 4)
+
+  res <- tune::finalize_workflow(wf, params)
+
+  expect_s3_class(res, "workflow")
+  extracted_spec <- workflows::extract_spec_parsnip(res)
+  expect_equal(extracted_spec$args$num_clusters, new_empty_quosure(4))
+})
+
 test_that("finalize_model_tidyclust() is deprecated", {
   spec <- k_means(num_clusters = tune())
   params <- data.frame(num_clusters = 5)

--- a/tests/testthat/test-finalize.R
+++ b/tests/testthat/test-finalize.R
@@ -1,4 +1,6 @@
 test_that("finalize_model_tidyclust() updates parameters", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   spec <- k_means(num_clusters = tune())
   params <- data.frame(num_clusters = 5)
 
@@ -9,6 +11,8 @@ test_that("finalize_model_tidyclust() updates parameters", {
 })
 
 test_that("finalize_model_tidyclust() works with tibble parameters", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   spec <- k_means(num_clusters = tune())
   params <- tibble::tibble(num_clusters = 3)
 
@@ -19,13 +23,24 @@ test_that("finalize_model_tidyclust() works with tibble parameters", {
 })
 
 test_that("finalize_model_tidyclust() errors on non-cluster_spec", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   expect_snapshot(
     error = TRUE,
     finalize_model_tidyclust("not a spec", data.frame(num_clusters = 5))
   )
 })
 
+test_that("finalize_model_tidyclust() is deprecated", {
+  spec <- k_means(num_clusters = tune())
+  params <- data.frame(num_clusters = 5)
+
+  expect_snapshot(. <- finalize_model_tidyclust(spec, params))
+})
+
 test_that("finalize_workflow_tidyclust() works with workflows", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   spec <- k_means(num_clusters = tune())
   wf <- workflows::workflow() |>
     workflows::add_model(spec) |>
@@ -41,8 +56,20 @@ test_that("finalize_workflow_tidyclust() works with workflows", {
 })
 
 test_that("finalize_workflow_tidyclust() errors on non-workflow", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   expect_snapshot(
     error = TRUE,
     finalize_workflow_tidyclust("not a workflow", data.frame(num_clusters = 5))
   )
+})
+
+test_that("finalize_workflow_tidyclust() is deprecated", {
+  spec <- k_means(num_clusters = tune())
+  wf <- workflows::workflow() |>
+    workflows::add_model(spec) |>
+    workflows::add_formula(~.)
+  params <- data.frame(num_clusters = 4)
+
+  expect_snapshot(. <- finalize_workflow_tidyclust(wf, params))
 })


### PR DESCRIPTION
to close #223 