### PR TITLE
Fix roxygen2 quotes in hier_clust()

### DIFF
--- a/R/hier_clust.R
+++ b/R/hier_clust.R
@@ -47,21 +47,21 @@
 #'   observation.
 #' - *centroid method*: The new observation is assigned to the cluster with the
 #'   closest centroid, as in prediction for k_means.
-#’ - *Ward’s method*: The new observation is assigned to the cluster with the
-#’   smallest increase in **error sum of squares (ESS)** due to the new
-#’   addition. The ESS is computed as the sum of squared distances between
-#’   observations in a cluster, and the centroid of the cluster.
-#’
-#’ Note that these heuristics for assigning new observations to existing
-#’ clusters are approximations. For most linkage methods, the predictions on
-#’ training data may not match the cluster assignments from
-#’ `extract_cluster_assignment()`. This is because `extract_cluster_assignment()`
-#’ uses `cutree()` to cut the fitted dendrogram, which assigns clusters based on
-#’ the dendrogram structure rather than proximity to existing cluster members.
-#’ Observations on the boundary between clusters may therefore be assigned to
-#’ different clusters by the two methods.
-#’
-#’ @return A `hier_clust` cluster specification.
+#' - *Ward’s method*: The new observation is assigned to the cluster with the
+#'   smallest increase in **error sum of squares (ESS)** due to the new
+#'   addition. The ESS is computed as the sum of squared distances between
+#'   observations in a cluster, and the centroid of the cluster.
+#'
+#' Note that these heuristics for assigning new observations to existing
+#' clusters are approximations. For most linkage methods, the predictions on
+#' training data may not match the cluster assignments from
+#' `extract_cluster_assignment()`. This is because `extract_cluster_assignment()`
+#' uses `cutree()` to cut the fitted dendrogram, which assigns clusters based on
+#' the dendrogram structure rather than proximity to existing cluster members.
+#' Observations on the boundary between clusters may therefore be assigned to
+#' different clusters by the two methods.
+#'
+#' @return A `hier_clust` cluster specification.
 #'
 #' @examples
 #' # Show all engines

--- a/man/hier_clust.Rd
+++ b/man/hier_clust.Rd
@@ -37,6 +37,9 @@ metrics via its \code{method} argument. The function should accept a matrix or
 data frame and return a square numeric matrix or an object coercible to one
 via \code{\link[stats:dist]{stats::as.dist()}}. See \code{\link[=silhouette]{silhouette()}} for further details.}
 }
+\value{
+A \code{hier_clust} cluster specification.
+}
 \description{
 \code{hier_clust()} defines a model that fits clusters based on a distance-based
 dendrogram
@@ -65,7 +68,20 @@ smallest average distances between training observations and the new
 observation.
 \item \emph{centroid method}: The new observation is assigned to the cluster with the
 closest centroid, as in prediction for k_means.
+\item \emph{Ward’s method}: The new observation is assigned to the cluster with the
+smallest increase in \strong{error sum of squares (ESS)} due to the new
+addition. The ESS is computed as the sum of squared distances between
+observations in a cluster, and the centroid of the cluster.
 }
+
+Note that these heuristics for assigning new observations to existing
+clusters are approximations. For most linkage methods, the predictions on
+training data may not match the cluster assignments from
+\code{extract_cluster_assignment()}. This is because \code{extract_cluster_assignment()}
+uses \code{cutree()} to cut the fitted dendrogram, which assigns clusters based on
+the dendrogram structure rather than proximity to existing cluster members.
+Observations on the boundary between clusters may therefore be assigned to
+different clusters by the two methods.
 }
 }
 \examples{


### PR DESCRIPTION
The docs for `hier_clust()` were updated in #228 but the wrong delimiter was used, so they didn't end up in 0.3.0.