### PR TITLE
Document authoring custom cluster metrics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyclust (development version)
 
+* `new_cluster_metric()` documentation now shows how to author a custom clustering metric, such as wrapping `silhouette_avg()` with a non-default `dist_fun`, for use with `cluster_metric_set()`. (#254)
+
 # tidyclust 0.3.0
 
 ## Deprecation

--- a/R/metric-aaa.R
+++ b/R/metric-aaa.R
@@ -1,11 +1,19 @@
 #' Construct a new clustering metric function
 #'
-#' @description These functions provide convenient wrappers to create the one
-#'   type of metric functions in celrry: clustering metrics. They add a
+#' @description This function provides a convenient wrapper to create the one
+#'   type of metric function used in tidyclust: clustering metrics. It adds a
 #'   metric-specific class to `fn`. These features are used by
 #'   [cluster_metric_set()] and by [tune_cluster()] when tuning.
 #'
-#' @param fn A function.
+#'   Use `new_cluster_metric()` when you want to author your own clustering
+#'   metric, for example to call [silhouette_avg()] with a non-default
+#'   `dist_fun`. A plain function cannot be passed to [cluster_metric_set()]
+#'   directly; it must first be wrapped with `new_cluster_metric()` so that it
+#'   carries the `cluster_metric` class.
+#'
+#' @param fn A function. It should take `object` and `new_data` as its first
+#'   two arguments and return a single-row tibble, as produced by the built-in
+#'   metrics such as [silhouette_avg()].
 #'
 #' @return A `cluster_metric` object.
 #'
@@ -14,6 +22,22 @@
 #'   - `"minimize"`
 #'   - `"zero"`
 #'
+#' @seealso [cluster_metric_set()]
+#'
+#' @examples
+#' # Author a custom metric that uses a non-default distance function. Here we
+#' # use the average silhouette with Chebyshev (L-infinity) distance.
+#' linf_dist <- function(x) philentropy::distance(x, method = "chebyshev")
+#'
+#' linf_silhouette_avg <- new_cluster_metric(
+#'   function(object, new_data = NULL, ...) {
+#'     silhouette_avg(object, new_data = new_data, dist_fun = linf_dist, ...)
+#'   },
+#'   direction = "maximize"
+#' )
+#'
+#' # The custom metric can now be combined with others in a metric set.
+#' cluster_metric_set(linf_silhouette_avg, sse_ratio)
 #' @export
 new_cluster_metric <- function(fn, direction) {
   if (!is.function(fn)) {
@@ -46,8 +70,13 @@ new_cluster_metric <- function(fn, direction) {
 #' @return A `cluster_metric_set()` object, combining the use of all input
 #'   metrics.
 #'
-#' @details All functions must be:
-#' - Only cluster metrics
+#' @details All functions must be cluster metrics. To include a metric that
+#' wraps a built-in metric with custom arguments, such as [silhouette_avg()]
+#' with a non-default `dist_fun`, first wrap it with [new_cluster_metric()] so
+#' that it carries the `cluster_metric` class. See the examples in
+#' [new_cluster_metric()].
+#'
+#' @seealso [new_cluster_metric()]
 #' @export
 cluster_metric_set <- function(...) {
   quo_fns <- rlang::enquos(...)

--- a/man/cluster_metric_set.Rd
+++ b/man/cluster_metric_set.Rd
@@ -20,8 +20,12 @@ metrics.
 together into a new function that calculates all of them at once.
 }
 \details{
-All functions must be:
-\itemize{
-\item Only cluster metrics
+All functions must be cluster metrics. To include a metric that
+wraps a built-in metric with custom arguments, such as \code{\link[=silhouette_avg]{silhouette_avg()}}
+with a non-default \code{dist_fun}, first wrap it with \code{\link[=new_cluster_metric]{new_cluster_metric()}} so
+that it carries the \code{cluster_metric} class. See the examples in
+\code{\link[=new_cluster_metric]{new_cluster_metric()}}.
 }
+\seealso{
+\code{\link[=new_cluster_metric]{new_cluster_metric()}}
 }

--- a/man/new_cluster_metric.Rd
+++ b/man/new_cluster_metric.Rd
@@ -7,7 +7,9 @@
 new_cluster_metric(fn, direction)
 }
 \arguments{
-\item{fn}{A function.}
+\item{fn}{A function. It should take \code{object} and \code{new_data} as its first
+two arguments and return a single-row tibble, as produced by the built-in
+metrics such as \code{\link[=silhouette_avg]{silhouette_avg()}}.}
 
 \item{direction}{A string. One of:
 \itemize{
@@ -20,8 +22,32 @@ new_cluster_metric(fn, direction)
 A \code{cluster_metric} object.
 }
 \description{
-These functions provide convenient wrappers to create the one
-type of metric functions in celrry: clustering metrics. They add a
+This function provides a convenient wrapper to create the one
+type of metric function used in tidyclust: clustering metrics. It adds a
 metric-specific class to \code{fn}. These features are used by
 \code{\link[=cluster_metric_set]{cluster_metric_set()}} and by \code{\link[=tune_cluster]{tune_cluster()}} when tuning.
+
+Use \code{new_cluster_metric()} when you want to author your own clustering
+metric, for example to call \code{\link[=silhouette_avg]{silhouette_avg()}} with a non-default
+\code{dist_fun}. A plain function cannot be passed to \code{\link[=cluster_metric_set]{cluster_metric_set()}}
+directly; it must first be wrapped with \code{new_cluster_metric()} so that it
+carries the \code{cluster_metric} class.
+}
+\examples{
+# Author a custom metric that uses a non-default distance function. Here we
+# use the average silhouette with Chebyshev (L-infinity) distance.
+linf_dist <- function(x) philentropy::distance(x, method = "chebyshev")
+
+linf_silhouette_avg <- new_cluster_metric(
+  function(object, new_data = NULL, ...) {
+    silhouette_avg(object, new_data = new_data, dist_fun = linf_dist, ...)
+  },
+  direction = "maximize"
+)
+
+# The custom metric can now be combined with others in a metric set.
+cluster_metric_set(linf_silhouette_avg, sse_ratio)
+}
+\seealso{
+\code{\link[=cluster_metric_set]{cluster_metric_set()}}
 }

--- a/tests/testthat/test-cluster_metric_set.R
+++ b/tests/testthat/test-cluster_metric_set.R
@@ -100,6 +100,36 @@ test_that("new_cluster_metric() works", {
   expect_equal(attr(metric, "direction"), "maximize")
 })
 
+test_that("custom metric wrapping a built-in metric works in cluster_metric_set()", {
+  kmeans_fit <- k_means(num_clusters = 5) |>
+    set_engine("stats") |>
+    fit(~., mtcars)
+
+  manhattan_dist <- function(x) philentropy::distance(x, method = "manhattan")
+
+  manhattan_silhouette_avg <- new_cluster_metric(
+    function(object, new_data = NULL, ...) {
+      silhouette_avg(
+        object,
+        new_data = new_data,
+        dist_fun = manhattan_dist,
+        ...
+      )
+    },
+    direction = "maximize"
+  )
+
+  my_metrics <- cluster_metric_set(manhattan_silhouette_avg, sse_ratio)
+
+  res <- my_metrics(kmeans_fit, new_data = mtcars)
+
+  expect_equal(res$.metric, c("silhouette_avg", "sse_ratio"))
+  expect_equal(
+    res$.estimate[[1]],
+    silhouette_avg_vec(kmeans_fit, new_data = mtcars, dist_fun = manhattan_dist)
+  )
+})
+
 test_that("new_cluster_metric() errors with non-function", {
   expect_snapshot(
     error = TRUE,


### PR DESCRIPTION
Closes #254.

The issue reported that there's no documentation on how to specify a custom `dist_fun` (or otherwise customize a metric) when adding it to `cluster_metric_set()`. Passing a plain wrapper function fails because `cluster_metric_set()` requires inputs to carry the `cluster_metric` class, and `new_cluster_metric()` (the mechanism for that) had no worked example.

This PR:

- Clarifies the `new_cluster_metric()` description, documents the expected `fn` signature, and adds an example showing how to wrap `silhouette_avg()` with a non-default `dist_fun` and combine it into a `cluster_metric_set()`.
- Adds a `@details` note and `@seealso` cross-reference from `cluster_metric_set()` to `new_cluster_metric()`.
- Fixes a typo ("celrry") in the description.

Documentation-only change, so no NEWS bullet per project convention.