### PR TITLE
Label cluster_metric_set() output with supplied metric names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyclust (development version)
 
+* `cluster_metric_set()` now labels each metric in its output with the name supplied to it, so multiple metrics that wrap the same built-in metric (for example `silhouette_avg()` with different `dist_fun` values) no longer collide and silently merge. (#257)
+
 * `new_cluster_metric()` documentation now shows how to author a custom clustering metric, such as wrapping `silhouette_avg()` with a non-default `dist_fun`, for use with `cluster_metric_set()`. (#254)
 
 # tidyclust 0.3.0

--- a/R/metric-aaa.R
+++ b/R/metric-aaa.R
@@ -220,6 +220,13 @@ make_cluster_metric_function <- function(fns) {
       SIMPLIFY = FALSE,
       USE.NAMES = FALSE
     )
+    metric_list <- mapply(
+      FUN = relabel_metric,
+      metric_list,
+      names(fns),
+      SIMPLIFY = FALSE,
+      USE.NAMES = FALSE
+    )
     dplyr::bind_rows(metric_list)
   }
   class(metric_function) <- c(
@@ -229,6 +236,13 @@ make_cluster_metric_function <- function(fns) {
   )
   attr(metric_function, "metrics") <- fns
   metric_function
+}
+
+relabel_metric <- function(res, name) {
+  if (is.data.frame(res) && ".metric" %in% names(res)) {
+    res[[".metric"]] <- name
+  }
+  res
 }
 
 eval_safely <- function(expr, expr_nm, data = NULL, env = rlang::caller_env()) {

--- a/tests/testthat/test-cluster_metric_set.R
+++ b/tests/testthat/test-cluster_metric_set.R
@@ -123,10 +123,58 @@ test_that("custom metric wrapping a built-in metric works in cluster_metric_set(
 
   res <- my_metrics(kmeans_fit, new_data = mtcars)
 
-  expect_equal(res$.metric, c("silhouette_avg", "sse_ratio"))
+  expect_equal(res$.metric, c("manhattan_silhouette_avg", "sse_ratio"))
   expect_equal(
     res$.estimate[[1]],
     silhouette_avg_vec(kmeans_fit, new_data = mtcars, dist_fun = manhattan_dist)
+  )
+})
+
+test_that("metrics wrapping the same built-in stay distinct in a metric set", {
+  kmeans_fit <- k_means(num_clusters = 5) |>
+    set_engine("stats") |>
+    fit(~., mtcars)
+
+  manhattan_dist <- function(x) philentropy::distance(x, method = "manhattan")
+  euclidean_dist <- function(x) philentropy::distance(x, method = "euclidean")
+
+  mk <- function(f) {
+    new_cluster_metric(
+      function(object, new_data = NULL, ...) {
+        silhouette_avg(object, new_data = new_data, dist_fun = f, ...)
+      },
+      direction = "maximize"
+    )
+  }
+
+  manhattan_silhouette_avg <- mk(manhattan_dist)
+  euclidean_silhouette_avg <- mk(euclidean_dist)
+
+  my_metrics <- cluster_metric_set(
+    manhattan_silhouette_avg,
+    euclidean_silhouette_avg
+  )
+
+  res <- my_metrics(kmeans_fit, new_data = mtcars)
+
+  expect_equal(
+    res$.metric,
+    c("manhattan_silhouette_avg", "euclidean_silhouette_avg")
+  )
+  expect_equal(
+    res$.estimate,
+    c(
+      silhouette_avg_vec(
+        kmeans_fit,
+        new_data = mtcars,
+        dist_fun = manhattan_dist
+      ),
+      silhouette_avg_vec(
+        kmeans_fit,
+        new_data = mtcars,
+        dist_fun = euclidean_dist
+      )
+    )
   )
 })
 


### PR DESCRIPTION
Closes #257.

When a custom metric created with `new_cluster_metric()` wraps a built-in metric (such as `silhouette_avg()` with a non-default `dist_fun`), the output `.metric` label previously came from the inner built-in metric rather than the name supplied to `cluster_metric_set()`. As a result, two variants of the same built-in (e.g. Chebyshev and Euclidean silhouette) collided and were silently averaged together.

This relabels each metric's result with the name it was given in `cluster_metric_set()`, so variants stay distinct. Built-in metrics used under their own names are unaffected, since the supplied name already matches their `.metric` value.

I verified the fix both with a direct metric-set call and through a full `tune_cluster()` resampling run, and added tests covering the distinct-naming case.