### PR TITLE
Fix tune_args() error with namespaced function arguments (#261)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyclust (development version)
 
+* `tune_args()` no longer errors when a model argument is set to a namespaced function such as `dist_fun = stats::dist`, which previously broke tuning of other arguments. (#261)
+
 # tidyclust 0.3.1
 
 ## Bug Fixes

--- a/R/tune_args.R
+++ b/R/tune_args.R
@@ -113,7 +113,8 @@ tune_id <- function(x) {
 
     # [tune()] will always return a call object
     if (is.call(x)) {
-      if (rlang::call_name(x) == "tune") {
+      nm <- rlang::call_name(x)
+      if (!is.null(nm) && nm == "tune") {
         # If an id was specified:
         if (length(x) > 1) {
           return(x[[2]])

--- a/R/tune_args.R
+++ b/R/tune_args.R
@@ -111,10 +111,11 @@ tune_id <- function(x) {
       }
     }
 
-    # [tune()] will always return a call object
+    # [tune()] will always return a simple call object. `is_call_simple()`
+    # guards against namespaced calls like `pkg::fun`, for which
+    # `call_name()` returns `NULL` (#261).
     if (is.call(x)) {
-      nm <- rlang::call_name(x)
-      if (!is.null(nm) && nm == "tune") {
+      if (rlang::is_call_simple(x) && rlang::call_name(x) == "tune") {
         # If an id was specified:
         if (length(x) > 1) {
           return(x[[2]])
@@ -122,7 +123,6 @@ tune_id <- function(x) {
           # no id
           return("")
         }
-        return(x$id)
       } else {
         return(NA_character_)
       }

--- a/tests/testthat/test-tune_cluster.R
+++ b/tests/testthat/test-tune_cluster.R
@@ -724,3 +724,43 @@ test_that("tune_args() works with a non-simple call argument (#261)", {
 
   expect_equal(res$id, "num_clusters")
 })
+
+test_that("tune_args() works with an anonymous function argument (#261)", {
+  spec <- hier_clust(
+    num_clusters = tune(),
+    dist_fun = function(x) stats::dist(x)
+  )
+
+  res <- tune_args(spec)
+
+  expect_equal(res$id, "num_clusters")
+})
+
+test_that("tune_args() handles a non-simple call argument with no tuning (#261)", {
+  spec <- hier_clust(
+    num_clusters = 3,
+    dist_fun = stats::dist
+  )
+
+  res <- tune_args(spec)
+
+  expect_equal(nrow(res), 0L)
+})
+
+test_that("tune_cluster() works with a namespaced dist_fun (#261)", {
+  spec <- hier_clust(
+    num_clusters = tune(),
+    dist_fun = stats::dist
+  )
+  folds <- rsample::vfold_cv(mtcars, v = 2)
+
+  res <- tune_cluster(
+    spec,
+    ~.,
+    resamples = folds,
+    grid = 3
+  )
+
+  expect_s3_class(res, "tune_results")
+  expect_equal(res$id, folds$id)
+})

--- a/tests/testthat/test-tune_cluster.R
+++ b/tests/testthat/test-tune_cluster.R
@@ -711,3 +711,16 @@ test_that("tune_args() works with a namespaced function argument (#261)", {
 
   expect_equal(res$id, "num_clusters")
 })
+
+test_that("tune_args() works with a non-simple call argument (#261)", {
+  funs <- list(euclidean = stats::dist)
+
+  spec <- hier_clust(
+    num_clusters = tune(),
+    dist_fun = funs$euclidean
+  )
+
+  res <- tune_args(spec)
+
+  expect_equal(res$id, "num_clusters")
+})

--- a/tests/testthat/test-tune_cluster.R
+++ b/tests/testthat/test-tune_cluster.R
@@ -700,3 +700,14 @@ test_that("tune_cluster works with validation set and tuned model", {
   expect_equal(nrow(res_est), nrow(grid) * 2)
   expect_true(best$num_clusters %in% grid$num_clusters)
 })
+
+test_that("tune_args() works with a namespaced function argument (#261)", {
+  spec <- hier_clust(
+    num_clusters = tune(),
+    dist_fun = stats::dist
+  )
+
+  res <- tune_args(spec)
+
+  expect_equal(res$id, "num_clusters")
+})


### PR DESCRIPTION
Fixes #261.

## Problem

Setting a model argument to a namespaced function, e.g. `hier_clust(num_clusters = tune(), dist_fun = philentropy::distance)`, caused `tune_cluster()` / `tune_args()` to error with `argument is of length zero`.

The argument expression `pkg::fun` is a `::` call, for which `rlang::call_name()` returns `NULL`. The check `rlang::call_name(x) == "tune"` then became `NULL == "tune"`, which is length-zero and errors inside `if()`.

## Fix

In `tune_id()`, capture the call name once and guard against `NULL`:

```r
nm <- rlang::call_name(x)
if (!is.null(nm) && nm == "tune") {
```

Added a test confirming `tune_args()` works with `dist_fun = stats::dist`, and a NEWS bullet.